### PR TITLE
Fix possible results page constructor typo

### DIFF
--- a/src/app/pages/results/results.page.ts
+++ b/src/app/pages/results/results.page.ts
@@ -14,7 +14,7 @@ export class ResultsPage implements OnInit {
 
   constructor(private uService: UserService) {
     this.attributes = this.uService.attributes$.getValue();
-    this.maxAttributes = this.uService.attributes$.getValue();
+    this.maxAttributes = this.uService.maxAttributes$.getValue();
     this.uService.attributes$.subscribe((val) => {
       this.attributes = val;
       this.generateTable();


### PR DESCRIPTION
Constructor was initially pulling from attributes instead of maxAttributes meaning the results page would initially show 100% for all values